### PR TITLE
Restore plugin functionality after 15 Nov 2019 changes on seasonvar.ru

### DIFF
--- a/resources/site-packages/seasonvar/parser.py
+++ b/resources/site-packages/seasonvar/parser.py
@@ -95,12 +95,12 @@ def episodes(playlist):
     for entry in playlist:
         if 'playlist' in entry:
             for episode in entry['playlist']:
-                fl = re.sub(r"\/\/.*?=", '', episode['file'])
+                fl = re.sub(r"//.*?=", '', episode['file'])
                 fl = base64.b64decode(fl[2:])
                 yield {'url': fl,
                        'name': episode['title'].replace('<br>', ' ')}
         else:
-            fl = re.sub(r"\/\/.*?=", '', entry['file'])
+            fl = re.sub(r"//.*?=", '', entry['file'])
             fl = base64.b64decode(fl[2:])
             yield {'url': fl,
                    'name': entry['title'].replace('<br>', ' ')}
@@ -122,8 +122,7 @@ def _season_and_serial(season_page_html):
 def _secure_and_time(season_page_html):
     r = re.compile(r"var\s+data4play\s*=\s*{\s*"
                    r"'secureMark'\s*:\s*'([a-f0-9]+)',\s*"
-                   r"'time'\s*:\s*([0-9]+)\s*"
-                   r"}")
+                   r"'time'\s*:\s*([0-9]+)\s*")
     match = r.search(season_page_html)
     if match:
         return match.groups()


### PR DESCRIPTION
    1) Fix parsing "data4play" variable:
      example of previous value:
        var data4play = {
            'secureMark': '45a672b1563b29c401677fa2f101afe7',
            'time': 1573838053
        }
      example of actual variant:
        var data4play = {
            'secureMark': '45a672b1563b29c401677fa2f101afe7',
            'time': 1573838053,
            'addr': 3285084633
        }
    
    2) Fix decode URL of episode video
    
      Example of actual variant is
    
        #2aHR0cDovL3RlbXAtY2RuLmRhdGFsb2NrLnJ1L2ZpMmxtLzQ1YTY3MmIxNTYzYjI5YzQwMTY3N2ZhMmYxMDFhZmU3Lz//b2xvbG8=dmX1lvdW5nLlNoZWxkb24uUzAzRTA3LjcyMHAuS2Vyb2IuYTEuMTUuMTEuMTkubXA0
                                                                                                    ^--------^ <-- trash
      As i remember previously trash piece started with '\/\/'
