### PR TITLE
Fix test online

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
 testpaths = resources/site-packages
 norecursedirs = .git assets
-
+markers =
+    online: make test as real site test

--- a/resources/site-packages/seasonvar/__init__.py
+++ b/resources/site-packages/seasonvar/__init__.py
@@ -27,6 +27,8 @@ def thumb_url(season_url):
 def seasons(season_url):
     r = Requester()
     p = r.season_page(season_url)
+    if p is None:
+        return None, None
     params = parser.player_params(p)
     if params is None:
         return None, None
@@ -38,9 +40,13 @@ def seasons(season_url):
 def season_info(season_url):
     r = Requester()
     p = r.season_page(season_url)
+    if p is None:
+        return {}
+
     params = parser.player_params(p)
     if params is None:
         return {}
+
     seasons = list(parser.seasons(p))
     snum = [n for n, u in enumerate(seasons, 1) if u == season_url][0]
     p = r.player(season_url, params)

--- a/resources/site-packages/seasonvar/parser.py
+++ b/resources/site-packages/seasonvar/parser.py
@@ -6,6 +6,7 @@
 # Distributed under terms of the MIT license.
 #
 import re
+import base64
 
 season_and_serial_re = re.compile(r'data-id-season="(\d+)"\s+data-id-serial="(\d+)"')
 
@@ -99,12 +100,35 @@ def episodes(playlist):
     for entry in playlist:
         if 'playlist' in entry:
             for episode in entry['playlist']:
-                yield {'url': episode['file'],
+                yield {'url': _decode_episode_file_to_url(episode['file']),
                        'name': episode['title'].replace('<br>', ' ')}
         else:
-            yield {'url': entry['file'],
+            yield {'url': _decode_episode_file_to_url(entry['file']),
                    'name': entry['title'].replace('<br>', ' ')}
 
+
+episode_link_preambula = '#2'
+episode_link_trash = (r'\/\/b2xvbG8=', r'//b2xvbG8=')
+
+def _decode_episode_file_to_url(enc_url):
+    '''
+    seasonvar.ru developers uses a trick to decode episode plain URL, i.e.
+        http://data11-cdn.datalock.ru/fi2lm/0b621d3fbcbe74cfeb0fbe93d5dc1512/7f_Detstvo.Sheldona.KB.S6E02.a1.28.10.22.mp4
+    is encoded as
+        #2aHR0cDovL2RhdGExMS1jZG4uZGF0YWxvY2sucnUvZmkybG0vMGI2MjFkM2ZiY2JlNzRjZmViMGZiZTkzZDVkYzE1MTIvN2ZfRGV0c3R2by5TaGVsZG9uYS5LQi5TNkUwMi5hMS4yOC4xMC\/\/b2xvbG8=4yMi5tcDQ=
+    Rules are simple:
+    * remove preambule '#2'
+    * remove trash '\/\/b2xvbG8='
+    * decode from base64
+    '''
+    enc_url = enc_url.replace(episode_link_preambula, '', 1)
+    for trash in episode_link_trash:
+        enc_url = enc_url.replace(trash, '', 1)
+    try:
+        return base64.b64decode(enc_url).decode('utf-8')
+    except:
+        import pdb; pdb.set_trace()
+        return ''
 
 def _translate_list(season_page_html):
     r = re.compile(r'<ul class="pgs-trans"(.*?)</ul>', re.DOTALL)

--- a/resources/site-packages/seasonvar/parser.py
+++ b/resources/site-packages/seasonvar/parser.py
@@ -7,6 +7,11 @@
 #
 import re
 
+season_and_serial_re = re.compile(r'data-id-season="(\d+)"\s+data-id-serial="(\d+)"')
+
+secure_and_time_re = re.compile(r"var\s+data4play\s*=\s*{\s*"
+                                r"'secureMark'\s*:\s*'([a-f0-9]+)',\s*"
+                                r"'time'\s*:\s*'([0-9]+)'\s*")
 
 def main_page_items(main_page_html, datestr):
     '''Collect all dayblock items(i.e episode changes) for a given date
@@ -108,20 +113,13 @@ def _translate_list(season_page_html):
 
 
 def _season_and_serial(season_page_html):
-    r = re.compile(r'data-id-season="(\d+)"\s+data-id-serial="(\d+)"')
-    match = r.search(season_page_html)
-    if match:
-        return match.groups()
+    m = season_and_serial_re.search(season_page_html)
+    return m and m.groups() or None
 
 
 def _secure_and_time(season_page_html):
-    r = re.compile(r"var\s+data4play\s*=\s*{\s*"
-                   r"'secureMark'\s*:\s*'([a-f0-9]+)',\s*"
-                   r"'time'\s*:\s*([0-9]+)\s*"
-                   r"}")
-    match = r.search(season_page_html)
-    if match:
-        return match.groups()
+    m = secure_and_time_re.search(season_page_html)
+    return m and m.groups() or None
 
 
 def _main_page_dayblocks(full_page_html):

--- a/resources/site-packages/seasonvar/requester.py
+++ b/resources/site-packages/seasonvar/requester.py
@@ -74,7 +74,10 @@ class Requester(object):
         season url should be urlencoded utf-8 str
         '''
         url = urljoin(self.BASEURL, season_url)
-        return utf8(self._get(url).text)
+        try:
+            return utf8(self._get(url).text)
+        except:
+            return None
 
     def player(self, referer, player_params):
         '''return utf-8 encoded response from player.php
@@ -82,7 +85,10 @@ class Requester(object):
         '''
         url = urljoin(self.BASEURL, '/player.php')
         refurl = urljoin(self.BASEURL, referer)
-        return utf8(self._xhtml(url, refurl, player_params).text)
+        try:
+            return utf8(self._xhtml(url, refurl, player_params).text)
+        except:
+            return None
 
     def playlist(self, url):
         '''get playlist and return dict representing utf-8 encoded json'''

--- a/resources/site-packages/seasonvar/tests/assets/playlist.json
+++ b/resources/site-packages/seasonvar/tests/assets/playlist.json
@@ -1,65 +1,9 @@
-[
-    {
-        "title": "1 \u0441\u0435\u0440\u0438\u044f SD/HD<br>LostFilm",
-        "file": "http://data11-cdn.datalock.ru/fi2lm/47deaa43b246218ac9fa7b54551fcdb7/7f_Arrow.S06E01.720p.WEB.rus.LostFilm.TV.a1.14.10.17.mp4",
-        "subtitle": "",
-        "galabel": "16337_484566",
-        "id": "1"
-    },
-    {
-        "title": "2 \u0441\u0435\u0440\u0438\u044f SD/HD<br>LostFilm",
-        "file": "http://data02-cdn.datalock.ru/fi2lm/47deaa43b246218ac9fa7b54551fcdb7/7f_Arrow.S06E02.720p.WEB.rus.LostFilm.TV.a1.22.10.17.mp4",
-        "subtitle": "",
-        "galabel": "16337_485808",
-        "id": "2"
-    },
-    {
-        "title": "3 \u0441\u0435\u0440\u0438\u044f SD/HD<br>LostFilm",
-        "file": "http://data08-cdn.datalock.ru/fi2lm/47deaa43b246218ac9fa7b54551fcdb7/7f_Arrow.S06E03.720p.WEB.rus.LostFilm.TV.a1.28.10.17.mp4",
-        "subtitle": "",
-        "galabel": "16337_487084",
-        "id": "3"
-    },
-    {
-        "title": "4 \u0441\u0435\u0440\u0438\u044f SD/HD<br>LostFilm",
-        "file": "http://data02-cdn.datalock.ru/fi2lm/47deaa43b246218ac9fa7b54551fcdb7/7f_Arrow.S06E04.720p.WEB.rus.LostFilm.TV.a1.04.11.17.mp4",
-        "subtitle": "",
-        "galabel": "16337_488375",
-        "id": "4"
-    },
-    {
-        "title": "5 \u0441\u0435\u0440\u0438\u044f SD/HD<br>LostFilm",
-        "file": "http://data13-cdn.datalock.ru/fi2lm/47deaa43b246218ac9fa7b54551fcdb7/7f_Arrow.S06E05.720p.WEB.rus.LostFilm.TV.a1.12.11.17.mp4",
-        "subtitle": "",
-        "galabel": "16337_490089",
-        "id": "5"
-    },
-    {
-        "title": "6 \u0441\u0435\u0440\u0438\u044f SD/HD<br>LostFilm",
-        "file": "http://temp-cdn.datalock.ru/fi2lm/47deaa43b246218ac9fa7b54551fcdb7/7f_Arrow.S06E06.720p.WEB.rus.LostFilm.TV.a1.19.11.17.mp4",
-        "subtitle": "",
-        "galabel": "16337_491169",
-        "id": "6"
-    },
-    {
-        "title": "7 \u0441\u0435\u0440\u0438\u044f SD/HD<br>LostFilm",
-        "file": "http://temp-cdn.datalock.ru/fi2lm/47deaa43b246218ac9fa7b54551fcdb7/7f_Arrow.S06E07.720p.WEB.rus.LostFilm.TV.a1.25.11.17.mp4",
-        "subtitle": "",
-        "galabel": "16337_492261",
-        "id": "7"
-    },
-    {
-        "title": "8 \u0441\u0435\u0440\u0438\u044f SD/HD<br>LostFilm",
-        "file": "http://temp-cdn.datalock.ru/fi2lm/47deaa43b246218ac9fa7b54551fcdb7/7f_Arrow.S06E08.720p.WEB.rus.LostFilm.TV.a1.30.11.17.mp4",
-        "subtitle": "",
-        "galabel": "16337_493242",
-        "id": "8"
-    },
-    {
-        "title": "9 \u0441\u0435\u0440\u0438\u044f SD/HD<br>ColdFilm",
-        "file": "http://temp-cdn.datalock.ru/fi2lm/47deaa43b246218ac9fa7b54551fcdb7/7f_Arrow.S06E09.720p.HDTV.ColdFilm.RU.a1.08.12.17.mp4",
-        "subtitle": "",
-        "galabel": "16337_494934",
-        "id": "9"
-    }
-]
+[{"title":"1 \u0441\u0435\u0440\u0438\u044f SD\/HD<br>\u041a\u0443\u0440\u0430\u0436-\u0411\u0430\u043c\u0431\u0435\u0439",
+"file":"#2aHR0cDovL2RhdGEwMS1jZG4uZGF0YWxvY2sucnUvZmkybG0vMGI2MjFkM2ZiY2JlNzRjZmViMGZiZTkzZDVkYzE1MTIvN2ZfRGV0c3R2by5TaGVsZG9uYS5LQi5TNkUwMS5hMS4yOC4xMC4yMi\/\/b2xvbG8=5tcDQ=","subtitle":"","galabel":"33965_876052","id":"1","vars":"876052"},{"title":"2 \u0441\u0435\u0440\u0438\u044f SD\/HD<br>\u041a\u0443\u0440\u0430\u0436-\u0411\u0430\u043c\u0431\u0435\u0439",
+"file":"#2aHR0cDovL2RhdGExMS1jZG4uZGF0YWxvY2sucnUvZmkybG0vMGI2MjFkM2ZiY2JlNzRjZmViMGZiZTkzZDVkYzE1MTIvN2ZfRGV0c3R2by5TaGVsZG9uYS5LQi5TNkUwMi5hMS4yOC4xMC\/\/b2xvbG8=4yMi5tcDQ=","subtitle":"","galabel":"33965_876053","id":"2","vars":"876053"},{"title":"3 \u0441\u0435\u0440\u0438\u044f SD\/HD<br>\u041a\u0443\u0440\u0430\u0436-\u0411\u0430\u043c\u0431\u0435\u0439",
+"file":"#2aHR0cDovL2RhdGEwMi1jZG4uZGF0YWxvY2sucnUvZmkybG0vMGI2MjFkM2ZiY2JlNzRjZmViMGZiZTkzZDVkYzE1\/\/b2xvbG8=MTIvN2ZfRGV0c3R2by5TaGVsZG9uYS5LQi5TNkUwMy5hMS4yOC4xMC4yMi5tcDQ=","subtitle":"","galabel":"33965_876054","id":"3","vars":"876054"},{"title":"4 \u0441\u0435\u0440\u0438\u044f SD\/HD<br>\u041a\u0443\u0440\u0430\u0436-\u0411\u0430\u043c\u0431\u0435\u0439",
+"file":"#2aHR0cDovL2RhdGExMS1jZG4uZGF0YWxvY2sucnUvZmkybG0vMGI2MjFkM2ZiY2JlNzRjZmViMGZiZTkzZDVkYzE1MTIvN2ZfRGV0c3R2by5TaGVsZG9uYS5LQi5TNkUwNC5hMS4yOC4xMC4yMi5t\/\/b2xvbG8=cDQ=","subtitle":"","galabel":"33965_876055","id":"4","vars":"876055"},{"title":"5 \u0441\u0435\u0440\u0438\u044f SD\/HD<br>\u041a\u0443\u0440\u0430\u0436-\u0411\u0430\u043c\u0431\u0435\u0439",
+"file":"#2aHR0cDovL2RhdGEwMS1jZG4uZGF0YWxvY2sucnUvZmkybG0vMGI2MjFkM2ZiY2JlNzRjZmViMGZiZTkzZDVkYzE1MTIvN2ZfRGV0c3R2by5TaGVsZG9uYS5LQi5TNkUwNS5hMS4wMy4xM\/\/b2xvbG8=S4yMi5tcDQ=","subtitle":"","galabel":"33965_877067","id":"5","vars":"877067"},{"title":"6 \u0441\u0435\u0440\u0438\u044f SD\/HD<br>\u041a\u0443\u0440\u0430\u0436-\u0411\u0430\u043c\u0431\u0435\u0439",
+"file":"#2aHR0cDovL2RhdGEwMi1jZG4uZGF0YWxvY2sucnUvZmkybG0vMGI2MjFkM2ZiY2JlNzRjZmViMGZiZTkzZDVkYzE1MTIvN2ZfRGV0c3R2by5TaGVsZG9uYS5LQi5TNkUwNi5hM\/\/b2xvbG8=S4xMC4xMS4yMi5tcDQ=","subtitle":"","galabel":"33965_878490","id":"6","vars":"878490"},{"title":"7 \u0441\u0435\u0440\u0438\u044f SD\/HD<br>\u041a\u0443\u0440\u0430\u0436-\u0411\u0430\u043c\u0431\u0435\u0439",
+"file":"#2aHR0cDovL2RhdGExMS1jZG4uZGF0YWxvY2sucnUvZmkybG0vMGI2MjFkM2ZiY2JlNzRjZmViMGZiZTkzZDVkYzE1MTIvN2ZfRGV0c3R2by5TaGVsZG9uYS5LQi5\/\/b2xvbG8=TNkUwNy5hMS4xOC4xMS4yMi5tcDQ=","subtitle":"","galabel":"33965_880868","id":"7","vars":"880868"},{"title":"8 \u0441\u0435\u0440\u0438\u044f SD\/HD<br>ColdFilm",
+"file":"#2aHR0cDovL3RlbXAtY2RuLmRhdGFsb2NrLnJ1L2ZpMmxtLzBiNjIxZDNmYmNiZTc0Y2ZlYjBmYmU5M2Q1ZGMxNTEyLzdmX1lvdW5nLlNoZWxkb24uUzA2RTA4LjcyMHA\/\/b2xvbG8=uQ29sZEZpbG0uYTEuMDkuMTIuMjIubXA0","subtitle":"","galabel":"33965_884427","id":"8","vars":"884427"}]

--- a/resources/site-packages/seasonvar/tests/assets/serial-example-playerparams.html
+++ b/resources/site-packages/seasonvar/tests/assets/serial-example-playerparams.html
@@ -3,7 +3,7 @@
 		<script type="text/javascript">
 			var data4play = {
 				'secureMark': '5acb2c2457a75ece192de4cdc669358f',
-				'time': 1491254539
+				'time': '1491254539'
 			}
 		</script>
 	</div>

--- a/resources/site-packages/seasonvar/tests/test_online.py
+++ b/resources/site-packages/seasonvar/tests/test_online.py
@@ -88,7 +88,7 @@ def test_pase_latin_search_items_online(term, min_suggestions):
                     reason='almost all content is blocked in US')
 @pytest.mark.online
 def test_play_online_episodes():
-    info = season_info('/serial-13945-Horoshee_mesto.html')
+    info = season_info('/serial-33965-Molodoj_SHeldon-6-season.html')
     assert info is not None
     assert 'playlist' in info
     assert len(info['playlist']) > 0

--- a/resources/site-packages/seasonvar/tests/test_online.py
+++ b/resources/site-packages/seasonvar/tests/test_online.py
@@ -12,7 +12,7 @@ import requests
 import seasonvar.parser as parser
 from seasonvar.requester import Requester
 from seasonvar import day_items, season_info, episodes
-from datetime import datetime
+from datetime import datetime, timedelta
 
 
 @pytest.mark.online
@@ -28,8 +28,10 @@ def test_parse_main_page_dayblocks():
 
 @pytest.mark.online
 def test_parse_main_page_items_online():
-    date = datetime.today()
-    datestr = date.strftime('%d.%m.%Y')
+    # We don't have episodes updates today because day may just start
+    # So check yesterday
+    yesterday = datetime.today() - timedelta(days=1)
+    datestr = yesterday.strftime('%d.%m.%Y')
     changes = list(day_items(datestr))
     assert len(changes) > 0
     for c in changes:
@@ -45,8 +47,10 @@ def test_parse_main_page_items_online():
                     reason='almost all content is blocked in US')
 @pytest.mark.online
 def test_parse_playlists_online():
-    date = datetime.today()
-    datestr = date.strftime('%d.%m.%Y')
+    # We don't have episodes updates today because day may just start
+    # So check yesterday
+    yesterday = datetime.today() - timedelta(days=1)
+    datestr = yesterday.strftime('%d.%m.%Y')
     changes = list(day_items(datestr))
     assert len(changes) > 0
     info_found = 0

--- a/resources/site-packages/seasonvar/tests/test_parser.py
+++ b/resources/site-packages/seasonvar/tests/test_parser.py
@@ -8,12 +8,21 @@
 import json
 import os
 import pytest
+from pytest_check import check
 import pprint
 import seasonvar.parser as parser
 
 
 def assetpath(path):
     return os.path.join(os.path.dirname(__file__), 'assets', path)
+
+
+def test_decode_episode_file_to_url():
+    check.equal('http://data08-cdn.datalock.ru/fi2lm/0b621d3fbcbe74cfeb0fbe93d5dc1512/7f_AniMaunt.-.[Animaunt].Voshozhdenie.v.teni.-.Kage.no.Jitsuryokusha.ni.Naritakute.-.01.seriya.mnogogolosaya.ozvuchka.a1.26.10.22.mp4',
+                parser._decode_episode_file_to_url('#2aHR0cDovL2RhdGEwOC1jZG4uZGF0YWxvY2sucnUvZmkybG0vMGI2MjFkM2ZiY2JlNzRjZmViMGZiZTkzZDVkYzE1MTIvN2ZfQW5pTWF1bnQuLS5bQW5pbWF1bnRdLlZvc2hvemhkZW5pZS52LnRlbmkuLS5LYWdlLm5vLkppdHN1cnlva3VzaGEubmkuTmFyaXRha3V0ZS4tLjAxLnNlcml5YS5tbm9nb2dvbG9zYXlhLm96dnVjaGthLmExLjI2LjEwLjIyLm1wNA=='))
+
+    check.equal('http://data11-cdn.datalock.ru/fi2lm/0b621d3fbcbe74cfeb0fbe93d5dc1512/7f_Detstvo.Sheldona.KB.S6E02.a1.28.10.22.mp4',
+                parser._decode_episode_file_to_url('#2aHR0cDovL2RhdGExMS1jZG4uZGF0YWxvY2sucnUvZmkybG0vMGI2MjFkM2ZiY2JlNzRjZmViMGZiZTkzZDVkYzE1MTIvN2ZfRGV0c3R2by5TaGVsZG9uYS5LQi5TNkUwMi5hMS4yOC4xMC\/\/b2xvbG8=4yMi5tcDQ='))
 
 
 @pytest.mark.parametrize('asset, expected_dates', [
@@ -103,7 +112,7 @@ def test_parse_playlists(asset, expected_count):
 
 
 @pytest.mark.parametrize('asset, expected_count', [
-    ('playlist.json', 9),
+    ('playlist.json', 8),
 ])
 def test_parse_episodes(asset, expected_count):
     with open(assetpath(asset)) as f:


### PR DESCRIPTION
New schema with decode episode URL
    
    seasonvar.ru developers uses a trick to decode episode plain URL, i.e.
        http://data11-cdn.datalock.ru/fi2lm/0b621d3fbcbe74cfeb0fbe93d5dc1512/7f_Detstvo.Sheldona.KB.S6E02.a1.28.10.22.mp4
    is encoded as
        #2aHR0cDovL2RhdGExMS1jZG4uZGF0YWxvY2sucnUvZmkybG0vMGI2MjFkM2ZiY2JlNzRjZmViMGZiZTkzZDVkYzE1MTIvN2ZfRGV0c3R2by5TaGVsZG9uYS5LQi5TNkUwMi5hMS4yOC4xMC\/\/b2xvbG8=4yMi5tcDQ=
    Rules:
    * remove preambule '#2'
    * remove trash '\/\/b2xvbG8='
    * decode from base64

requester.py: add handling errors on pages downloading
    
    Return None on non 200 code

test_online.py: test yesterday updates instead of today
    
      We don't have episodes updates today if day just started
      So check yesterday to have guarantee that episodes exist

parser.py: preliminary regex compilation for seasons, serial and secure time
    
      For performance improvement

pytest.ini: add "online" marker
    
      Required by pytest from some version
